### PR TITLE
Move the mock network interface into a mock api utils repo.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const mockServer = require('graphql-tools').mockServer;
+const MockNetworkInterface = require('./src/MockNetworkInterface');
 
-module.exports = { mockServer }
+module.exports = { MockNetworkInterface };

--- a/index.test.js
+++ b/index.test.js
@@ -1,10 +1,16 @@
 const schema = require('eq-author-graphql-schema/schema');
 
-const merge = require('lodash').merge;
+const { merge } = require('lodash');
+const { mockServer } = require('graphql-tools');
 
-const mockServer = require('./index').mockServer;
+const { MockNetworkInterface } = require('./index');
 
 describe('mock API', () => {
+
+    it('should be possible to create a mock network interface', () => {
+        const networkInterface = new MockNetworkInterface(schema);
+        expect(networkInterface).toBeInstanceOf(MockNetworkInterface);
+    });
 
     describe('no overridden behaviours', () => {
 

--- a/index.test.js
+++ b/index.test.js
@@ -23,14 +23,12 @@ describe('mock API', () => {
                 }
             }`;
 
-            server.query(query).then(r => {
+            return server.query(query).then(r => {
                 const result = r.data;
 
                 expect(result.questionnaires).toHaveLength(2);
                 expect(result.questionnaires[0].title).toEqual("Hello World");
-            }).catch(e => {
-                console.error(e);
-            });
+            })
         });
 
         it('should allow default implementation for more complex queries', () => {
@@ -71,7 +69,7 @@ describe('mock API', () => {
                   }
             }`;
 
-            server.query(query, {questionnaireId: 1}).then(r => {
+            return server.query(query, {questionnaireId: 1}).then(r => {
                 const result = r.data;
                 expect(['Voluntary', 'StatisticsOfTradeAct']).toContain(result.questionnaire.legalBasis);
 
@@ -87,9 +85,7 @@ describe('mock API', () => {
                 const mockPageType = sections[0].pages[0].pageType;
                 expect(validPageTypes).toContain(mockPageType);
 
-            }).catch(e => {
-                console.error(e);
-            });
+            })
 
         });
 
@@ -133,16 +129,14 @@ describe('mock API', () => {
                 legalBasis: "Voluntary"
             };
 
-            server.query(query, vars).then(r => {
+            return server.query(query, vars).then(r => {
                 const result = r.data.updateQuestionnaire;
 
                 // Because we haven't specified the mock resolver functions the
                 // mock resolver will generate some default data for us.
                 expect(result.title).toEqual('Hello World');
                 expect([true, false]).toContain(result.navigation);
-            }).catch(e => {
-                console.error(e);
-            });
+            })
 
         });
 
@@ -167,15 +161,12 @@ describe('mock API', () => {
                 }
             }`;
 
-            server.query(query).then(result => {
+            return server.query(query).then(result => {
                 const questionnaire = result.data.questionnaires[0];
                 expect(questionnaire.id).toEqual(99);
                 expect(questionnaire.title).toEqual('Survey title');
                 expect(questionnaire.navigation).toBe(true);
-            }).catch(e => {
-                console.error(e);
             });
-
         });
 
     });
@@ -203,14 +194,12 @@ describe('mock API', () => {
                 }
             }`;
 
-            server.query(query).then(result => {
+            return server.query(query).then(result => {
                 const questionnaire = result.data.questionnaires[0];
 
                 expect(questionnaire.id).toEqual(1);
                 expect(questionnaire.title).toEqual("something");
                 expect(questionnaire.navigation).toBe(false);
-            }).catch(e => {
-                console.error(e);
             });
 
         });
@@ -270,11 +259,9 @@ describe('mock API', () => {
                 legalBasis: "Voluntary"
             };
 
-            server.query(query, vars).then(r => {
+            return server.query(query, vars).then(r => {
                 const result = r.data.updateQuestionnaire;
                 expect(result).toMatchObject(vars);
-            }).catch(e => {
-                console.error(e);
             });
 
         });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "eq-author-graphql-schema": "https://github.com/ONSdigital/eq-author-graphql-schema.git",
     "graphql": "^0.10.5",
+    "graphql-tag": "^2.4.2",
     "graphql-tools": "^1.1.0",
     "lodash": "^4.17.4"
   },

--- a/src/MockNetworkInterface.js
+++ b/src/MockNetworkInterface.js
@@ -1,0 +1,17 @@
+const { mockServer } = require("graphql-tools");
+const { print } = require("graphql/language/printer");
+
+class MockNetworkInterface {
+  constructor(schema, mocks = {}) {
+    if (schema === undefined) {
+      throw new Error('Cannot create Mock Api without specifying a schema');
+    }
+    this.mockServer = mockServer(schema, mocks);
+  }
+
+  query(request) {
+    return this.mockServer.query(print(request.query), request.variables);
+  }
+}
+
+module.exports = MockNetworkInterface;

--- a/src/MockNetworkInterface.test.js
+++ b/src/MockNetworkInterface.test.js
@@ -1,0 +1,37 @@
+const MockNetworkInterface = require("./MockNetworkInterface");
+const schema = require("eq-author-graphql-schema/schema");
+const gql = require("graphql-tag");
+
+describe("mock network interface", () => {
+
+  describe('constructor', () => {
+
+    it('should not be possible to initialise the mock API without a schema', () => {
+      expect(() => new MockNetworkInterface()).toThrowError(/schema/);
+    });
+
+  });
+
+  it("should be possible to query the mock network interface", () => {
+    const api = new MockNetworkInterface(schema);
+
+    const query = gql`
+      {
+        questionnaires {
+          id
+        }
+      }
+    `;
+
+    const request = {
+      query,
+      variables: {}
+    };
+
+    api.query(request).then(result => {
+      // If request query was passed to the mockServer implementation successfully then we should have
+      // two questionnaires returned by default.
+      expect(result.data.questionnaires).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?
This PR moves the implementation of the MockNetworkInterface into the eq-author-mock-api repo.
This has been done to centralise the dependency between the Publisher and Author projects.

### How to review 
All tests pass. The publisher and the Author will be refactored to use this module.
