### PR TITLE
Remove dependency on schema.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "eq-author-graphql-schema": "https://github.com/ONSdigital/eq-author-graphql-schema.git",
     "graphql": "^0.10.5",
     "graphql-tag": "^2.4.2",
     "graphql-tools": "^1.1.0",

--- a/src/MockNetworkInterface.test.js
+++ b/src/MockNetworkInterface.test.js
@@ -1,6 +1,15 @@
 const MockNetworkInterface = require("./MockNetworkInterface");
-const schema = require("eq-author-graphql-schema/schema");
 const gql = require("graphql-tag");
+
+const schema = `
+type Questionnaire {
+    id: Int
+}
+
+type Query {
+    questionnaires: [Questionnaire]
+}
+`;
 
 describe("mock network interface", () => {
 
@@ -16,11 +25,11 @@ describe("mock network interface", () => {
     const api = new MockNetworkInterface(schema);
 
     const query = gql`
-      {
-        questionnaires {
-          id
+        {
+            questionnaires {
+                id
+            }
         }
-      }
     `;
 
     const request = {


### PR DESCRIPTION
### What is the context of this PR?
The mock network interface test had a dependency on an older version of the schema.
This was causing an issue where the wrong version of the schema was being pulled in when doing a `yarn install`.
This change removes the dependency and introduces a mock implementation of the schema which satisfies the mock network interface unit tests.

### How to review 
All tests should pass.
